### PR TITLE
fix: include auth and ally config in inertia tsconfig

### DIFF
--- a/packages/platform/inertia/tsconfig.json
+++ b/packages/platform/inertia/tsconfig.json
@@ -8,5 +8,5 @@
       "~/*": ["./*"]
     }
   },
-  "include": ["./**/*.ts", "./**/*.tsx"]
+  "include": ["./**/*.ts", "./**/*.tsx", "../config/auth.ts", "../config/ally.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `../config/auth.ts` and `../config/ally.ts` to the inertia tsconfig `include` array so the `Authenticators` and `SocialProviders` module augmentations are in scope during the frontend compilation pass
- Server-side files get pulled into the inertia tsconfig context transitively via `/// <reference path="../../adonisrc.ts" />` in `app.tsx` and direct controller imports for `InferPageProps`. Without the config files in scope, `auth.use('web')` and `ally.use('fitbit')` resolve as `never`, cascading into ~70 type errors across all controllers
- Mirrors the fix from the [adonis-inertia-starter](https://github.com/jakeklassen/adonis-inertia-starter/pull/1) (`adb029a`), extended to also cover ally types

## Test plan

- [x] `pnpm -r typecheck` passes cleanly (both server and inertia tsconfig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)