### PR TITLE
Add daily average column to competition leaderboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,13 +204,22 @@ const validToken = await refreshService.getValidAccessToken(account);
 
 ## Development Practices
 
-### Workflow
+### Branching
 
-All development work goes through GitHub issues, feature branches, and pull requests. Do not push directly to `main` unless explicitly granted permission. The flow is: issue → branch → PR → review → merge.
+All work happens on feature branches with pull requests. Never commit directly to `main` unless explicitly granted permission. Flow: issue → branch → PR → review → merge.
 
-### Test-Driven Development
+### Test-first workflow
 
-We follow TDD. Tests are required for feature development — write tests first, then implement. Use PGlite or Testcontainers for PostgreSQL in integration tests (no mocking the database).
+Every code change **must** include tests. Do not wait for the user to ask — treat tests as part of the implementation, not a follow-up.
+
+- **Bug fixes**: Write a test that reproduces the bug _before_ (or alongside) the fix. The test should fail without the fix and pass with it.
+- **New features / components**: Add component tests (`inertia/**/*.test.tsx`) or unit tests (`tests/unit/`) covering the key behaviors introduced.
+- **Refactors**: Ensure existing tests still pass; add tests if the refactor changes observable behavior.
+- **Backend endpoints**: Add or update functional tests (`tests/functional/`).
+
+When planning work, include a "Tests" section listing what will be tested. Before opening a PR, verify all new and existing tests pass (`npx vitest run`, `node ace test`).
+
+Use PGlite or Testcontainers for PostgreSQL in integration tests (no mocking the database).
 
 ### TypeScript
 

--- a/packages/platform/app/services/competition_service.ts
+++ b/packages/platform/app/services/competition_service.ts
@@ -10,6 +10,7 @@ export interface LeaderboardEntry {
   userId: number;
   user: User;
   totalSteps: number;
+  dailyAverage: number;
   rank: number;
   goalReached?: boolean; // For goal-based competitions
 }
@@ -45,6 +46,10 @@ export class CompetitionService {
       .preload('user');
 
     // Get steps for each member during competition period
+    const now = DateTime.now();
+    const end = competition.endDate < now ? competition.endDate : now;
+    const elapsedDays = Math.max(1, Math.ceil(end.diff(competition.startDate, 'days').days));
+
     const leaderboard: LeaderboardEntry[] = [];
 
     for (const member of members) {
@@ -62,6 +67,7 @@ export class CompetitionService {
         userId: member.userId,
         user: member.user,
         totalSteps,
+        dailyAverage: Math.round(totalSteps / elapsedDays),
         rank: 0, // Will be set below
         goalReached:
           competition.goalType === 'goal_based' && competition.goalValue

--- a/packages/platform/inertia/pages/competitions/show.tsx
+++ b/packages/platform/inertia/pages/competitions/show.tsx
@@ -49,6 +49,7 @@ interface LeaderboardEntry {
   userId: number;
   user: User;
   totalSteps: number;
+  dailyAverage: number;
   rank: number;
   goalReached?: boolean;
 }
@@ -249,6 +250,7 @@ export default function CompetitionShow({
                     <TableHead className="w-24">Rank</TableHead>
                     <TableHead>Participant</TableHead>
                     <TableHead className="text-right">Total Steps</TableHead>
+                    <TableHead className="text-right">Daily Avg</TableHead>
                     {competition.goalType === 'goal_based' && (
                       <TableHead className="text-center">Goal Status</TableHead>
                     )}
@@ -277,6 +279,9 @@ export default function CompetitionShow({
                       </TableCell>
                       <TableCell className={cn('text-right', getStepsTextSize(entry.rank))}>
                         {entry.totalSteps.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground">
+                        {entry.dailyAverage.toLocaleString()}
                       </TableCell>
                       {competition.goalType === 'goal_based' && (
                         <TableCell className="text-center">

--- a/packages/platform/tests/unit/services/competition_service.spec.ts
+++ b/packages/platform/tests/unit/services/competition_service.spec.ts
@@ -1,0 +1,219 @@
+import Competition from '#models/competition';
+import CompetitionMember from '#models/competition_member';
+import DailyStep from '#models/daily_step';
+import User from '#models/user';
+import { CompetitionService } from '#services/competition_service';
+import { test } from '@japa/runner';
+import { DateTime } from 'luxon';
+
+async function createTestUser(overrides: Partial<{ email: string; fullName: string }> = {}) {
+  return User.create({
+    email: overrides.email ?? `test-${Date.now()}-${Math.random()}@example.com`,
+    password: 'password123',
+    fullName: overrides.fullName ?? 'Test User',
+  });
+}
+
+async function createCompetition(
+  creator: User,
+  overrides: Partial<{
+    startDate: DateTime;
+    endDate: DateTime;
+    status: 'draft' | 'active' | 'ended';
+  }> = {},
+) {
+  const competition = await Competition.create({
+    name: `Test Competition ${Date.now()}`,
+    startDate: overrides.startDate ?? DateTime.now().minus({ days: 10 }),
+    endDate: overrides.endDate ?? DateTime.now().plus({ days: 18 }),
+    goalType: 'total_steps',
+    createdBy: creator.id,
+    status: overrides.status ?? 'active',
+    visibility: 'private',
+  });
+
+  await CompetitionMember.create({
+    competitionId: competition.id,
+    userId: creator.id,
+    status: 'accepted',
+    invitedBy: null,
+  });
+
+  return competition;
+}
+
+test.group('CompetitionService - getCompetitionStats', () => {
+  test('averageSteps is total steps divided by participant count', async ({ assert }) => {
+    const user1 = await createTestUser();
+    const user2 = await createTestUser();
+
+    const startDate = DateTime.now().minus({ days: 5 });
+    const competition = await createCompetition(user1, { startDate });
+
+    await CompetitionMember.create({
+      competitionId: competition.id,
+      userId: user2.id,
+      status: 'accepted',
+      invitedBy: user1.id,
+    });
+
+    // User 1: 60,000 total
+    for (let i = 0; i < 5; i++) {
+      await DailyStep.create({
+        userId: user1.id,
+        date: startDate.plus({ days: i }),
+        steps: 12_000,
+      });
+    }
+
+    // User 2: 40,000 total
+    for (let i = 0; i < 5; i++) {
+      await DailyStep.create({
+        userId: user2.id,
+        date: startDate.plus({ days: i }),
+        steps: 8_000,
+      });
+    }
+
+    const service = new CompetitionService();
+    const stats = await service.getCompetitionStats(competition.id, user1.id);
+
+    // (60,000 + 40,000) / 2 participants = 50,000
+    assert.equal(stats.averageSteps, 50_000);
+    assert.equal(stats.totalParticipants, 2);
+    assert.equal(stats.activeParticipants, 2);
+  });
+
+  test('averageSteps is 0 when no steps recorded', async ({ assert }) => {
+    const user = await createTestUser();
+
+    const competition = await createCompetition(user, {
+      startDate: DateTime.now().minus({ days: 5 }),
+      endDate: DateTime.now().plus({ days: 25 }),
+    });
+
+    const service = new CompetitionService();
+    const stats = await service.getCompetitionStats(competition.id, user.id);
+
+    assert.equal(stats.averageSteps, 0);
+    assert.equal(stats.activeParticipants, 0);
+  });
+});
+
+test.group('CompetitionService - leaderboard dailyAverage', () => {
+  test('dailyAverage is participant total steps divided by elapsed days', async ({ assert }) => {
+    const user = await createTestUser();
+
+    const startDate = DateTime.now().minus({ days: 10 });
+    const competition = await createCompetition(user, { startDate });
+
+    // 10 days × 10,000 = 100,000 total
+    for (let i = 0; i < 10; i++) {
+      await DailyStep.create({
+        userId: user.id,
+        date: startDate.plus({ days: i }),
+        steps: 10_000,
+      });
+    }
+
+    const service = new CompetitionService();
+    const stats = await service.getCompetitionStats(competition.id, user.id);
+    const entry = stats.leaderboard.find((e) => e.userId === user.id)!;
+
+    const elapsedDays = Math.ceil(DateTime.now().diff(startDate, 'days').days);
+    const expectedDailyAvg = Math.round(100_000 / elapsedDays);
+
+    assert.equal(entry.dailyAverage, expectedDailyAvg);
+    assert.notEqual(entry.dailyAverage, entry.totalSteps, 'Daily avg should differ from total');
+  });
+
+  test('dailyAverage for ended competition uses end date not today', async ({ assert }) => {
+    const user = await createTestUser();
+
+    const startDate = DateTime.now().minus({ days: 30 });
+    const endDate = DateTime.now().minus({ days: 2 });
+    const competition = await createCompetition(user, { startDate, endDate, status: 'ended' });
+
+    const totalDays = Math.ceil(endDate.diff(startDate, 'days').days);
+
+    for (let i = 0; i < totalDays; i++) {
+      await DailyStep.create({
+        userId: user.id,
+        date: startDate.plus({ days: i }),
+        steps: 10_000,
+      });
+    }
+
+    const service = new CompetitionService();
+    const stats = await service.getCompetitionStats(competition.id, user.id);
+    const entry = stats.leaderboard.find((e) => e.userId === user.id)!;
+
+    assert.equal(entry.dailyAverage, 10_000);
+  });
+
+  test('dailyAverage on first day uses minimum 1 day divisor', async ({ assert }) => {
+    const user = await createTestUser();
+
+    const competition = await createCompetition(user, {
+      startDate: DateTime.now(),
+      endDate: DateTime.now().plus({ days: 28 }),
+    });
+
+    await DailyStep.create({
+      userId: user.id,
+      date: DateTime.now(),
+      steps: 15_000,
+    });
+
+    const service = new CompetitionService();
+    const stats = await service.getCompetitionStats(competition.id, user.id);
+    const entry = stats.leaderboard.find((e) => e.userId === user.id)!;
+
+    assert.equal(entry.dailyAverage, 15_000);
+  });
+
+  test('each participant has their own dailyAverage', async ({ assert }) => {
+    const user1 = await createTestUser();
+    const user2 = await createTestUser();
+
+    const startDate = DateTime.now().minus({ days: 10 });
+    const competition = await createCompetition(user1, { startDate });
+
+    await CompetitionMember.create({
+      competitionId: competition.id,
+      userId: user2.id,
+      status: 'accepted',
+      invitedBy: user1.id,
+    });
+
+    // User 1: 120,000 total
+    for (let i = 0; i < 10; i++) {
+      await DailyStep.create({
+        userId: user1.id,
+        date: startDate.plus({ days: i }),
+        steps: 12_000,
+      });
+    }
+
+    // User 2: 50,000 total
+    for (let i = 0; i < 10; i++) {
+      await DailyStep.create({
+        userId: user2.id,
+        date: startDate.plus({ days: i }),
+        steps: 5_000,
+      });
+    }
+
+    const service = new CompetitionService();
+    const stats = await service.getCompetitionStats(competition.id, user1.id);
+
+    const entry1 = stats.leaderboard.find((e) => e.userId === user1.id)!;
+    const entry2 = stats.leaderboard.find((e) => e.userId === user2.id)!;
+
+    const elapsedDays = Math.ceil(DateTime.now().diff(startDate, 'days').days);
+
+    assert.equal(entry1.dailyAverage, Math.round(120_000 / elapsedDays));
+    assert.equal(entry2.dailyAverage, Math.round(50_000 / elapsedDays));
+    assert.isAbove(entry1.dailyAverage, entry2.dailyAverage);
+  });
+});


### PR DESCRIPTION
## Summary

- **Stats card**: "Average Steps" remains per-participant (`totalSteps / participantCount`) — meaningful when multiple people join
- **Leaderboard table**: Added "Daily Avg" column showing each participant's `totalSteps / elapsedDays`, capped at competition end date for ended competitions, with `Math.max(1, ...)` to prevent division by zero on day one
- **CLAUDE.md**: Updated development practices with detailed test-first workflow and branching guidelines

## Test plan

- [x] `averageSteps` stat is total steps / participant count
- [x] `averageSteps` is 0 when no steps recorded
- [x] `dailyAverage` per entry is total steps / elapsed days
- [x] Ended competitions use end date (not today) for daily average
- [x] First day uses minimum 1 day divisor
- [x] Each participant has their own independent daily average
- [x] All 36 tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)