### PR TITLE
Add friend profile page with step stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,8 @@ Use PGlite or Testcontainers for PostgreSQL in integration tests (no mocking the
 
 Lean into the type system. `any`, non-null assertions (`!`), and `@ts-ignore` are a last resort — there should almost always be a better way. Prefer `unknown` over `any`, narrow with type guards, and let inference do the work where types are obvious.
 
+**Auth in controllers**: Always use `auth.getUserOrFail()` instead of `auth.user!`. Never use non-null assertions to access the authenticated user.
+
 ### Code Style
 
 Write clean, non-claustrophobic code:

--- a/packages/platform/inertia/pages/friends/index.tsx
+++ b/packages/platform/inertia/pages/friends/index.tsx
@@ -158,13 +158,18 @@ export default function FriendsIndex({ friends, pendingRequests, sentRequests }:
                     )}
                   </CardHeader>
                   <CardContent>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => handleRemove(friend.friendshipId)}
-                    >
-                      Remove Friend
-                    </Button>
+                    <div className="flex gap-2">
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/friends/${friend.id}`}>View Profile</Link>
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleRemove(friend.friendshipId)}
+                      >
+                        Remove Friend
+                      </Button>
+                    </div>
                   </CardContent>
                 </Card>
               ))}

--- a/packages/platform/inertia/pages/friends/show.tsx
+++ b/packages/platform/inertia/pages/friends/show.tsx
@@ -1,0 +1,119 @@
+import type { PageProps } from '@adonisjs/inertia/types';
+import { Head, Link } from '@inertiajs/react';
+import { format, parseISO } from 'date-fns';
+import { ArrowLeft, Footprints, TrendingUp } from 'lucide-react';
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '~/components/ui/chart';
+import AuthenticatedLayout from '~/layouts/authenticated-layout';
+
+interface DaySteps {
+  date: string;
+  steps: number;
+}
+
+interface Props extends PageProps {
+  friend: {
+    id: number;
+    fullName: string | null;
+  };
+  stats: {
+    todaySteps: number;
+    total30Days: number;
+    dailyAverage: number;
+    last7Days: DaySteps[];
+  };
+}
+
+const chartConfig = {
+  steps: {
+    label: 'Steps',
+    color: 'var(--chart-1)',
+  },
+} satisfies ChartConfig;
+
+export default function FriendShow({ friend, stats }: Props) {
+  const chartData = stats.last7Days.map((day) => ({
+    date: format(parseISO(day.date), 'EEE'),
+    steps: day.steps,
+  }));
+
+  return (
+    <AuthenticatedLayout>
+      <Head title={`${friend.fullName ?? 'Friend'}'s Profile`} />
+
+      <div className="container mx-auto max-w-7xl px-4 py-8">
+        {/* Back button */}
+        <Button variant="ghost" size="sm" className="mb-6" asChild>
+          <Link href="/friends">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Friends
+          </Link>
+        </Button>
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight">{friend.fullName ?? 'Friend'}</h1>
+          <p className="text-muted-foreground mt-1">Step activity overview</p>
+        </div>
+
+        {/* Stats Grid */}
+        <div className="grid gap-4 md:grid-cols-3 mb-8">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Today's Steps</CardTitle>
+              <Footprints className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.todaySteps.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Last 30 Days</CardTitle>
+              <Footprints className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.total30Days.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Daily Average (30d)</CardTitle>
+              <TrendingUp className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{stats.dailyAverage.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 7-Day Bar Chart */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Last 7 Days</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ChartContainer config={chartConfig} className="h-[300px] w-full">
+              <BarChart data={chartData} accessibilityLayer>
+                <CartesianGrid vertical={false} />
+                <XAxis dataKey="date" tickLine={false} axisLine={false} tickMargin={8} />
+                <YAxis tickLine={false} axisLine={false} tickMargin={8} />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Bar dataKey="steps" fill="var(--color-steps)" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ChartContainer>
+          </CardContent>
+        </Card>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/packages/platform/start/routes.ts
+++ b/packages/platform/start/routes.ts
@@ -56,6 +56,7 @@ router
     router.get('/friends', [FriendsController, 'index']).as('friends.index');
     router.get('/friends/add', [FriendsController, 'create']).as('friends.create');
     router.post('/friends/search', [FriendsController, 'search']).as('friends.search');
+    router.get('/friends/:userId', [FriendsController, 'show']).as('friends.show');
     router.post('/friends/:userId', [FriendsController, 'store']).as('friends.store');
     router.post('/friends/:id/accept', [FriendsController, 'accept']).as('friends.accept');
     router.post('/friends/:id/decline', [FriendsController, 'decline']).as('friends.decline');

--- a/packages/platform/tests/bootstrap.ts
+++ b/packages/platform/tests/bootstrap.ts
@@ -1,6 +1,7 @@
 import { assert } from '@japa/assert';
 import { apiClient } from '@japa/api-client';
 import { authApiClient } from '@adonisjs/auth/plugins/api_client';
+import { inertiaApiClient } from '@adonisjs/inertia/plugins/api_client';
 import { sessionApiClient } from '@adonisjs/session/plugins/api_client';
 import { shieldApiClient } from '@adonisjs/shield/plugins/api_client';
 import app from '@adonisjs/core/services/app';
@@ -23,6 +24,7 @@ export const plugins: Config['plugins'] = [
   shieldApiClient(),
   authApiClient(app),
   sessionApiClient(app),
+  inertiaApiClient(app),
 ];
 
 /**

--- a/packages/platform/tests/functional/friends/show.spec.ts
+++ b/packages/platform/tests/functional/friends/show.spec.ts
@@ -1,0 +1,218 @@
+import DailyStep from '#models/daily_step';
+import Friendship from '#models/friendship';
+import User from '#models/user';
+import { test } from '@japa/runner';
+import { DateTime } from 'luxon';
+
+test.group('FriendsController - show', () => {
+  test('accepted friend can view profile', async ({ client }) => {
+    const timestamp = Date.now();
+
+    const user = await User.create({
+      email: `viewer-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Viewer User',
+    });
+
+    const friend = await User.create({
+      email: `friend-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Friend User',
+    });
+
+    await Friendship.create({
+      userId: user.id,
+      friendId: friend.id,
+      status: 'accepted',
+    });
+
+    const response = await client.get(`/friends/${friend.id}`).loginAs(user).withInertia();
+
+    response.assertStatus(200);
+    response.assertInertiaComponent('friends/show');
+    response.assertInertiaPropsContains({
+      friend: { id: friend.id, fullName: 'Friend User' },
+    });
+  });
+
+  test('non-friend cannot view profile', async ({ client, assert }) => {
+    const timestamp = Date.now();
+
+    const user = await User.create({
+      email: `nonfriend-viewer-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Non Friend Viewer',
+    });
+
+    const stranger = await User.create({
+      email: `stranger-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Stranger',
+    });
+
+    const response = await client.get(`/friends/${stranger.id}`).loginAs(user).redirects(0);
+
+    response.assertStatus(302);
+
+    const location = response.header('location') ?? '';
+    assert.isTrue(location.endsWith('/friends'));
+  });
+
+  test('pending friendship is denied access', async ({ client, assert }) => {
+    const timestamp = Date.now();
+
+    const user = await User.create({
+      email: `pending-viewer-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Pending Viewer',
+    });
+
+    const pendingFriend = await User.create({
+      email: `pending-friend-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Pending Friend',
+    });
+
+    await Friendship.create({
+      userId: user.id,
+      friendId: pendingFriend.id,
+      status: 'pending',
+    });
+
+    const response = await client.get(`/friends/${pendingFriend.id}`).loginAs(user).redirects(0);
+
+    response.assertStatus(302);
+
+    const location = response.header('location') ?? '';
+    assert.isTrue(location.endsWith('/friends'));
+  });
+
+  test('reverse friendship direction works', async ({ client }) => {
+    const timestamp = Date.now();
+
+    const user = await User.create({
+      email: `reverse-viewer-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Reverse Viewer',
+    });
+
+    const friend = await User.create({
+      email: `reverse-friend-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Reverse Friend',
+    });
+
+    // Friend initiated the friendship, not the viewer
+    await Friendship.create({
+      userId: friend.id,
+      friendId: user.id,
+      status: 'accepted',
+    });
+
+    const response = await client.get(`/friends/${friend.id}`).loginAs(user).withInertia();
+
+    response.assertStatus(200);
+    response.assertInertiaComponent('friends/show');
+    response.assertInertiaPropsContains({
+      friend: { id: friend.id, fullName: 'Reverse Friend' },
+    });
+  });
+
+  test('email is not exposed in friend profile', async ({ client, assert }) => {
+    const timestamp = Date.now();
+
+    const user = await User.create({
+      email: `email-check-viewer-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Email Check Viewer',
+    });
+
+    const friend = await User.create({
+      email: `secret-email-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Secret Email Friend',
+    });
+
+    await Friendship.create({
+      userId: user.id,
+      friendId: friend.id,
+      status: 'accepted',
+    });
+
+    const response = await client.get(`/friends/${friend.id}`).loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const body = JSON.stringify(response.body());
+    assert.notInclude(body, `secret-email-${timestamp}@test.com`);
+  });
+
+  test('unauthenticated user is redirected', async ({ client }) => {
+    const timestamp = Date.now();
+
+    const friend = await User.create({
+      email: `unauth-friend-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Unauth Friend',
+    });
+
+    const response = await client.get(`/friends/${friend.id}`).redirects(0);
+
+    response.assertStatus(302);
+  });
+
+  test('step stats are returned correctly', async ({ client, assert }) => {
+    const timestamp = Date.now();
+
+    const user = await User.create({
+      email: `stats-viewer-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Stats Viewer',
+    });
+
+    const friend = await User.create({
+      email: `stats-friend-${timestamp}@test.com`,
+      password: 'password123',
+      fullName: 'Stats Friend',
+    });
+
+    await Friendship.create({
+      userId: user.id,
+      friendId: friend.id,
+      status: 'accepted',
+    });
+
+    const today = DateTime.now().startOf('day');
+
+    // Create step records for today and yesterday
+    await DailyStep.create({
+      userId: friend.id,
+      date: today,
+      steps: 10000,
+    });
+
+    await DailyStep.create({
+      userId: friend.id,
+      date: today.minus({ days: 1 }),
+      steps: 8000,
+    });
+
+    const response = await client.get(`/friends/${friend.id}`).loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as {
+      stats: {
+        todaySteps: number;
+        total30Days: number;
+        dailyAverage: number;
+        last7Days: { date: string; steps: number }[];
+      };
+    };
+
+    assert.equal(props.stats.todaySteps, 10000);
+    assert.equal(props.stats.total30Days, 18000);
+    assert.equal(props.stats.dailyAverage, Math.round(18000 / 30));
+    assert.lengthOf(props.stats.last7Days, 7);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a friend profile page (`GET /friends/:userId`) showing step activity for accepted friends
- Displays stats grid (today's steps, 30-day total, daily average) and a 7-day bar chart
- Adds "View Profile" button on friend cards in the friends index
- Registers the Inertia Japa test plugin for Inertia-aware assertions in functional tests

Closes #40

## Test plan

- [x] Accepted friend can view profile (200, correct component + props)
- [x] Non-friend gets redirected to `/friends`
- [x] Pending friendship is denied access
- [x] Reverse friendship direction works
- [x] Friend email is not exposed in response
- [x] Unauthenticated user is redirected
- [x] Step stats are returned correctly with zero-filled 7-day array
- [x] Full test suite passes (53/53)
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)