### PR TITLE
Rename Cancel Competition to Delete Competition

### DIFF
--- a/packages/platform/app/controllers/competitions_controller.ts
+++ b/packages/platform/app/controllers/competitions_controller.ts
@@ -243,15 +243,15 @@ export default class CompetitionsController {
   }
 
   /**
-   * Cancel (soft delete) a competition
+   * Delete (soft delete) a competition
    */
   async destroy({ auth, params, response, session }: HttpContext) {
     const user = auth.getUserOrFail();
     const competitionService = new CompetitionService();
 
     try {
-      await competitionService.cancelCompetition(params.id, user.id);
-      session.flash('success', 'Competition cancelled successfully');
+      await competitionService.deleteCompetition(params.id, user.id);
+      session.flash('success', 'Competition deleted successfully');
     } catch (error) {
       session.flash('error', error.message);
     }

--- a/packages/platform/app/services/competition_service.ts
+++ b/packages/platform/app/services/competition_service.ts
@@ -206,14 +206,14 @@ export class CompetitionService {
   }
 
   /**
-   * Soft delete (cancel) a competition
+   * Soft delete a competition
    */
-  async cancelCompetition(competitionId: number, userId: number): Promise<Competition> {
+  async deleteCompetition(competitionId: number, userId: number): Promise<Competition> {
     const competition = await Competition.findOrFail(competitionId);
 
-    // Only creator can cancel
+    // Only creator can delete
     if (competition.createdBy !== userId) {
-      throw new Error('Access denied: Only the competition creator can cancel it');
+      throw new Error('Access denied: Only the competition creator can delete it');
     }
 
     competition.deletedAt = DateTime.now();

--- a/packages/platform/inertia/pages/competitions/show.tsx
+++ b/packages/platform/inertia/pages/competitions/show.tsx
@@ -242,23 +242,23 @@ export default function CompetitionShow({
                       <AlertDialogTrigger asChild>
                         <Button variant="destructive">
                           <Trash2 className="mr-2 h-4 w-4" />
-                          Cancel
+                          Delete
                         </Button>
                       </AlertDialogTrigger>
                       <AlertDialogContent>
                         <AlertDialogHeader>
-                          <AlertDialogTitle>Cancel competition?</AlertDialogTitle>
+                          <AlertDialogTitle>Delete competition?</AlertDialogTitle>
                           <AlertDialogDescription>
-                            Are you sure you want to cancel this competition? This cannot be undone.
+                            Are you sure you want to delete this competition? This cannot be undone.
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
-                          <AlertDialogCancel>Keep</AlertDialogCancel>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
                           <AlertDialogAction
                             onClick={handleDelete}
                             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                           >
-                            Cancel Competition
+                            Delete Competition
                           </AlertDialogAction>
                         </AlertDialogFooter>
                       </AlertDialogContent>


### PR DESCRIPTION
## Summary
- Renamed all "Cancel" competition UI text to "Delete" — button labels, dialog title/description, and confirmation action
- Changed the dismiss button from "Keep" to "Cancel" (standard AlertDialog dismiss label)
- Renamed `cancelCompetition` service method to `deleteCompetition` and updated flash messages

Fixes #46

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all 53 tests pass
- [x] Manual: open a competition you created, click "Delete", verify dialog text and action work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)