### PR TITLE
Add competition discovery page

### DIFF
--- a/packages/platform/app/controllers/competition_discovery_controller.ts
+++ b/packages/platform/app/controllers/competition_discovery_controller.ts
@@ -1,0 +1,50 @@
+import {
+  CompetitionDiscoveryService,
+  type DiscoveryFilters,
+} from '#services/competition_discovery_service';
+import type { HttpContext } from '@adonisjs/core/http';
+
+export default class CompetitionDiscoveryController {
+  /**
+   * Display discoverable public competitions
+   */
+  async index({ auth, request, inertia }: HttpContext) {
+    const user = auth.getUserOrFail();
+
+    const search = request.input('search', '');
+    const status = request.input('status', '');
+    const source = request.input('source', 'all');
+
+    const filters: DiscoveryFilters = {
+      search: search || undefined,
+      status: status || undefined,
+      source: source || 'all',
+    };
+
+    const discoveryService = new CompetitionDiscoveryService();
+    const competitions = await discoveryService.discoverCompetitions(user.id, filters);
+
+    return inertia.render('competitions/discover', {
+      competitions,
+      filters: { search, status, source },
+    });
+  }
+
+  /**
+   * Join a public competition
+   */
+  async join({ auth, params, response, session }: HttpContext) {
+    const user = auth.getUserOrFail();
+    const discoveryService = new CompetitionDiscoveryService();
+
+    const result = await discoveryService.joinPublicCompetition(params.id, user.id);
+
+    if (result.error) {
+      session.flash('error', result.error);
+    } else {
+      session.flash('success', 'You have joined the competition!');
+    }
+
+    return response.redirect().toRoute('competitions.show', { id: params.id });
+  }
+}

--- a/packages/platform/app/services/competition_discovery_service.ts
+++ b/packages/platform/app/services/competition_discovery_service.ts
@@ -1,0 +1,157 @@
+import Competition from '#models/competition';
+import CompetitionMember from '#models/competition_member';
+import Friendship from '#models/friendship';
+import { CompetitionService } from '#services/competition_service';
+import logger from '@adonisjs/core/services/logger';
+
+export interface DiscoveryFilters {
+  search?: string;
+  status?: 'active' | 'ended';
+  source?: 'all' | 'friends';
+}
+
+export interface DiscoveredCompetition {
+  competition: Competition;
+  memberCount: number;
+  userMembershipStatus: 'accepted' | 'invited' | 'declined' | null;
+}
+
+export class CompetitionDiscoveryService {
+  /**
+   * Discover public competitions with optional filters
+   */
+  async discoverCompetitions(
+    userId: number,
+    filters: DiscoveryFilters,
+  ): Promise<DiscoveredCompetition[]> {
+    const query = Competition.query()
+      .where('visibility', 'public')
+      .whereNot('status', 'draft')
+      .whereNull('deleted_at')
+      .preload('creator')
+      .withCount('members', (q) => {
+        q.where('status', 'accepted');
+      });
+
+    if (filters.search) {
+      const searchTerm = `%${filters.search}%`;
+
+      query.where((group) => {
+        group.whereILike('name', searchTerm).orWhereILike('description', searchTerm);
+      });
+    }
+
+    if (filters.status) {
+      query.where('status', filters.status);
+    }
+
+    if (filters.source === 'friends') {
+      const friendIds = await this.getFriendIds(userId);
+
+      query.whereIn('created_by', friendIds);
+    }
+
+    // Order: active first, then ended; within each by created_at DESC
+    query.orderByRaw(`
+      CASE status
+        WHEN 'active' THEN 1
+        WHEN 'ended' THEN 2
+      END ASC
+    `);
+    query.orderBy('created_at', 'desc');
+
+    const competitions = await query;
+
+    // Load user's existing memberships in one query
+    const membershipMap = await this.getUserMemberships(userId);
+
+    return competitions.map((competition) => ({
+      competition,
+      memberCount: Number(competition.$extras.members_count),
+      userMembershipStatus: membershipMap.get(competition.id) ?? null,
+    }));
+  }
+
+  /**
+   * Join a public competition.
+   * Throws E_ROW_NOT_FOUND (404) if competition doesn't exist or is deleted.
+   * Returns `{ error }` for business logic failures (not public, already a member).
+   */
+  async joinPublicCompetition(
+    competitionId: number,
+    userId: number,
+  ): Promise<{ member: CompetitionMember; error?: never } | { member?: never; error: string }> {
+    // firstOrFail throws E_ROW_NOT_FOUND → 404 for missing/deleted competitions
+    const competition = await Competition.query()
+      .where('id', competitionId)
+      .whereNull('deleted_at')
+      .firstOrFail();
+
+    if (competition.visibility !== 'public') {
+      return { error: 'This competition is not public' };
+    }
+
+    if (competition.status === 'draft') {
+      return { error: 'This competition has not started yet' };
+    }
+
+    // Check for existing membership
+    const existing = await CompetitionMember.query()
+      .where('competition_id', competitionId)
+      .where('user_id', userId)
+      .first();
+
+    if (existing) {
+      return { error: 'You are already a member of this competition' };
+    }
+
+    const member = await CompetitionMember.create({
+      competitionId,
+      userId,
+      status: 'accepted',
+      invitedBy: null,
+    });
+
+    // Trigger backfill (fire-and-forget)
+    const competitionService = new CompetitionService();
+
+    competitionService.triggerBackfillForUser(competitionId, userId).catch((backfillError) => {
+      logger.error(
+        `Backfill failed for user ${userId} after joining competition ${competitionId}:`,
+        backfillError,
+      );
+    });
+
+    return { member };
+  }
+
+  /**
+   * Get IDs of the user's accepted friends (both directions)
+   */
+  private async getFriendIds(userId: number): Promise<number[]> {
+    const friendships = await Friendship.query()
+      .where((query) => {
+        query.where('user_id', userId).orWhere('friend_id', userId);
+      })
+      .where('status', 'accepted');
+
+    return friendships.map((f) => (f.userId === userId ? f.friendId : f.userId));
+  }
+
+  /**
+   * Get a map of competition ID → membership status for the user
+   */
+  private async getUserMemberships(
+    userId: number,
+  ): Promise<Map<number, 'accepted' | 'invited' | 'declined'>> {
+    const memberships = await CompetitionMember.query().where('user_id', userId);
+
+    const map = new Map<number, 'accepted' | 'invited' | 'declined'>();
+
+    for (const m of memberships) {
+      map.set(m.competitionId, m.status);
+    }
+
+    return map;
+  }
+}

--- a/packages/platform/app/services/competition_service.ts
+++ b/packages/platform/app/services/competition_service.ts
@@ -248,7 +248,7 @@ export class CompetitionService {
    * Trigger backfill for a user who joined a competition
    * Fetches historical data from competition start to today
    */
-  private async triggerBackfillForUser(competitionId: number, userId: number): Promise<void> {
+  async triggerBackfillForUser(competitionId: number, userId: number): Promise<void> {
     const competition = await Competition.findOrFail(competitionId);
     const backfillService = new StepsBackfillService();
 

--- a/packages/platform/inertia/pages/competitions/discover.tsx
+++ b/packages/platform/inertia/pages/competitions/discover.tsx
@@ -1,0 +1,260 @@
+import type { PageProps } from '@adonisjs/inertia/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { Calendar, Compass, Search, Target, User, Users } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
+import { Input } from '~/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
+import AuthenticatedLayout from '~/layouts/authenticated-layout';
+
+interface Competition {
+  id: number;
+  name: string;
+  description: string | null;
+  startDate: string;
+  endDate: string;
+  goalType: 'total_steps' | 'goal_based';
+  goalValue: number | null;
+  status: 'draft' | 'active' | 'ended';
+  createdBy: number;
+  creator: {
+    id: number;
+    fullName: string | null;
+    email: string;
+  };
+}
+
+interface DiscoveredCompetition {
+  competition: Competition;
+  memberCount: number;
+  userMembershipStatus: 'accepted' | 'invited' | 'declined' | null;
+}
+
+interface Filters {
+  search: string;
+  status: string;
+  source: string;
+}
+
+interface Props extends PageProps {
+  competitions: DiscoveredCompetition[];
+  filters: Filters;
+}
+
+export default function DiscoverCompetitions({ competitions, filters }: Props) {
+  const [searchValue, setSearchValue] = useState(filters.search || '');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const applyFilters = (newFilters: Partial<Filters>) => {
+    const merged = { ...filters, ...newFilters };
+
+    router.get(
+      '/competitions/discover',
+      {
+        search: merged.search || undefined,
+        status: merged.status || undefined,
+        source: merged.source === 'all' ? undefined : merged.source,
+      },
+      { preserveState: true, replace: true },
+    );
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchValue(value);
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      applyFilters({ search: value });
+    }, 300);
+  };
+
+  const handleStatusChange = (value: string) => {
+    applyFilters({ status: value === 'all' ? '' : value });
+  };
+
+  const handleSourceChange = (value: string) => {
+    applyFilters({ source: value });
+  };
+
+  const handleJoin = (competitionId: number) => {
+    router.post(`/competitions/${competitionId}/join`);
+  };
+
+  const getStatusVariant = (
+    status: string,
+  ): 'default' | 'secondary' | 'outline' | 'destructive' => {
+    const variants = {
+      draft: 'secondary' as const,
+      active: 'default' as const,
+      ended: 'outline' as const,
+    };
+    return variants[status as keyof typeof variants] || 'secondary';
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      timeZone: 'UTC',
+    }).format(date);
+  };
+
+  const getMembershipAction = (item: DiscoveredCompetition) => {
+    if (item.userMembershipStatus === 'accepted') {
+      return (
+        <Badge variant="secondary" className="shrink-0">
+          Joined
+        </Badge>
+      );
+    }
+
+    if (item.userMembershipStatus === 'invited') {
+      return (
+        <Badge variant="outline" className="shrink-0">
+          Invited
+        </Badge>
+      );
+    }
+
+    if (item.competition.status === 'ended') {
+      return null;
+    }
+
+    return (
+      <Button
+        size="sm"
+        className="shrink-0"
+        onClick={(e) => {
+          e.preventDefault();
+          handleJoin(item.competition.id);
+        }}
+      >
+        Join
+      </Button>
+    );
+  };
+
+  return (
+    <AuthenticatedLayout>
+      <Head title="Discover Competitions" />
+
+      <div className="container mx-auto max-w-7xl px-4 py-8">
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Discover Competitions</h1>
+            <p className="text-muted-foreground mt-1">Browse and join public fitness challenges</p>
+          </div>
+          <Button variant="outline" asChild>
+            <Link href="/competitions">My Competitions</Link>
+          </Button>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3 mb-8">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search competitions..."
+              value={searchValue}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Select value={filters.status || 'all'} onValueChange={handleStatusChange}>
+            <SelectTrigger className="w-full sm:w-[160px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Statuses</SelectItem>
+              <SelectItem value="active">Active</SelectItem>
+              <SelectItem value="ended">Ended</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={filters.source || 'all'} onValueChange={handleSourceChange}>
+            <SelectTrigger className="w-full sm:w-[160px]">
+              <SelectValue placeholder="Source" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Competitions</SelectItem>
+              <SelectItem value="friends">From Friends</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Results */}
+        {competitions.length === 0 ? (
+          <Card className="p-12 text-center">
+            <CardContent>
+              <Compass className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+              <p className="text-muted-foreground mb-2">No public competitions found.</p>
+              <p className="text-sm text-muted-foreground">
+                Try adjusting your filters or create your own competition.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {competitions.map((item) => (
+              <Card
+                key={item.competition.id}
+                className="h-full transition-all hover:shadow-lg hover:border-primary/50"
+              >
+                <CardHeader>
+                  <div className="flex justify-between items-start gap-2 mb-2">
+                    <CardTitle className="line-clamp-2">{item.competition.name}</CardTitle>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Badge variant={getStatusVariant(item.competition.status)}>
+                        {item.competition.status}
+                      </Badge>
+                    </div>
+                  </div>
+                  {item.competition.description && (
+                    <CardDescription className="line-clamp-2">
+                      {item.competition.description}
+                    </CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm text-muted-foreground">
+                  <p className="flex items-center gap-1.5">
+                    <Calendar className="w-4 h-4" />
+                    {formatDate(item.competition.startDate)} -{' '}
+                    {formatDate(item.competition.endDate)}
+                  </p>
+                  <p className="flex items-center gap-1.5">
+                    <Target className="w-4 h-4" />
+                    {item.competition.goalType === 'total_steps'
+                      ? 'Total Steps'
+                      : `Goal: ${item.competition.goalValue?.toLocaleString()} steps`}
+                  </p>
+                  <p className="flex items-center gap-1.5">
+                    <User className="w-4 h-4" />
+                    {item.competition.creator.fullName || item.competition.creator.email}
+                  </p>
+                  <p className="flex items-center gap-1.5">
+                    <Users className="w-4 h-4" />
+                    {item.memberCount} {item.memberCount === 1 ? 'member' : 'members'}
+                  </p>
+                  <div className="pt-2">{getMembershipAction(item)}</div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/packages/platform/inertia/pages/competitions/index.tsx
+++ b/packages/platform/inertia/pages/competitions/index.tsx
@@ -1,6 +1,6 @@
 import type { PageProps } from '@adonisjs/inertia/types';
 import { Head, Link, router } from '@inertiajs/react';
-import { Calendar, Plus, Target, User } from 'lucide-react';
+import { Calendar, Compass, Plus, Target, User } from 'lucide-react';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
@@ -83,12 +83,20 @@ export default function CompetitionsIndex({ competitions }: Props) {
               Create and join fitness challenges with friends
             </p>
           </div>
-          <Button asChild>
-            <Link href="/competitions/create">
-              <Plus className="mr-2 h-4 w-4" />
-              Create Competition
-            </Link>
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" asChild>
+              <Link href="/competitions/discover">
+                <Compass className="mr-2 h-4 w-4" />
+                Discover
+              </Link>
+            </Button>
+            <Button asChild>
+              <Link href="/competitions/create">
+                <Plus className="mr-2 h-4 w-4" />
+                Create Competition
+              </Link>
+            </Button>
+          </div>
         </div>
 
         {/* Pending Invitations */}
@@ -151,9 +159,14 @@ export default function CompetitionsIndex({ competitions }: Props) {
                 <p className="text-muted-foreground mb-4">
                   You haven't joined any competitions yet.
                 </p>
-                <Button asChild>
-                  <Link href="/competitions/create">Create Your First Competition</Link>
-                </Button>
+                <div className="flex justify-center gap-3">
+                  <Button variant="outline" asChild>
+                    <Link href="/competitions/discover">Discover Competitions</Link>
+                  </Button>
+                  <Button asChild>
+                    <Link href="/competitions/create">Create Your First Competition</Link>
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           ) : (

--- a/packages/platform/inertia/pages/competitions/show.tsx
+++ b/packages/platform/inertia/pages/competitions/show.tsx
@@ -225,9 +225,7 @@ export default function CompetitionShow({
                           </AlertDialogHeader>
                           <AlertDialogFooter>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={handleLaunch}>
-                              Launch
-                            </AlertDialogAction>
+                            <AlertDialogAction onClick={handleLaunch}>Launch</AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
                       </AlertDialog>

--- a/packages/platform/start/routes.ts
+++ b/packages/platform/start/routes.ts
@@ -15,6 +15,8 @@ const ProfilesController = () => import('#controllers/profiles_controller');
 const FitbitController = () => import('#controllers/fitbit_controller');
 const FriendsController = () => import('#controllers/friends_controller');
 const CompetitionsController = () => import('#controllers/competitions_controller');
+const CompetitionDiscoveryController = () =>
+  import('#controllers/competition_discovery_controller');
 const FitbitWebhookController = () => import('#controllers/fitbit_webhook_controller');
 
 // FitBit webhook routes (public, no auth/CSRF)
@@ -65,9 +67,15 @@ router
     // Competitions
     router.get('/competitions', [CompetitionsController, 'index']).as('competitions.index');
     router
+      .get('/competitions/discover', [CompetitionDiscoveryController, 'index'])
+      .as('competitions.discover');
+    router
       .get('/competitions/create', [CompetitionsController, 'create'])
       .as('competitions.create');
     router.post('/competitions', [CompetitionsController, 'store']).as('competitions.store');
+    router
+      .post('/competitions/:id/join', [CompetitionDiscoveryController, 'join'])
+      .as('competitions.join');
     router.get('/competitions/:id', [CompetitionsController, 'show']).as('competitions.show');
     router.get('/competitions/:id/edit', [CompetitionsController, 'edit']).as('competitions.edit');
     router.put('/competitions/:id', [CompetitionsController, 'update']).as('competitions.update');

--- a/packages/platform/tests/functional/competitions/discover.spec.ts
+++ b/packages/platform/tests/functional/competitions/discover.spec.ts
@@ -1,0 +1,604 @@
+import Competition from '#models/competition';
+import CompetitionMember from '#models/competition_member';
+import Friendship from '#models/friendship';
+import User from '#models/user';
+import { test } from '@japa/runner';
+import { DateTime } from 'luxon';
+
+test.group('CompetitionDiscoveryController - index', () => {
+  test('shows public competitions on discover page', async ({ client }) => {
+    const user = await User.create({
+      email: `discover-user-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Discover User',
+    });
+
+    const creator = await User.create({
+      email: `discover-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Competition Creator',
+    });
+
+    await Competition.create({
+      name: 'Public Challenge',
+      description: 'A public step challenge',
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    const response = await client.get('/competitions/discover').loginAs(user).withInertia();
+
+    response.assertStatus(200);
+    response.assertInertiaComponent('competitions/discover');
+    response.assertInertiaPropsContains({
+      filters: { search: '', status: '', source: 'all' },
+    });
+
+    const props = response.inertiaProps as any;
+    const competitions = props.competitions;
+
+    const found = competitions.find((c: any) => c.competition.name === 'Public Challenge');
+
+    if (!found) {
+      throw new Error('Expected to find "Public Challenge" in discover results');
+    }
+  });
+
+  test('does not show private competitions', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-private-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Private Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-private-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Private Creator',
+    });
+
+    const privateName = `Private Competition ${Date.now()}`;
+
+    await Competition.create({
+      name: privateName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'private',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    const response = await client.get('/competitions/discover').loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === privateName);
+
+    assert.isUndefined(found);
+  });
+
+  test('does not show deleted competitions', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-deleted-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Deleted Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-deleted-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Deleted Creator',
+    });
+
+    const deletedName = `Deleted Competition ${Date.now()}`;
+
+    await Competition.create({
+      name: deletedName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+      deletedAt: DateTime.now(),
+    });
+
+    const response = await client.get('/competitions/discover').loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === deletedName);
+
+    assert.isUndefined(found);
+  });
+
+  test('does not show draft competitions', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-draft-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Draft Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-draft-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Draft Creator',
+    });
+
+    const draftName = `Draft Competition ${Date.now()}`;
+
+    await Competition.create({
+      name: draftName,
+      startDate: DateTime.now().plus({ days: 10 }),
+      endDate: DateTime.now().plus({ days: 40 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'draft',
+    });
+
+    const response = await client.get('/competitions/discover').loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === draftName);
+
+    assert.isUndefined(found);
+  });
+
+  test('filters by search term', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-search-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Search Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-search-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Search Creator',
+    });
+
+    const uniqueName = `Unique Walkathon ${Date.now()}`;
+
+    await Competition.create({
+      name: uniqueName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    const response = await client
+      .get('/competitions/discover')
+      .qs({ search: 'Walkathon' })
+      .loginAs(user)
+      .withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === uniqueName);
+
+    assert.isDefined(found);
+  });
+
+  test('filters by status', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-status-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Status Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-status-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Status Creator',
+    });
+
+    const draftName = `Draft Public ${Date.now()}`;
+
+    await Competition.create({
+      name: draftName,
+      startDate: DateTime.now().plus({ days: 10 }),
+      endDate: DateTime.now().plus({ days: 40 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'draft',
+    });
+
+    const response = await client
+      .get('/competitions/discover')
+      .qs({ status: 'active' })
+      .loginAs(user)
+      .withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === draftName);
+
+    assert.isUndefined(found);
+  });
+
+  test('filters by friend source', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-friend-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Friend Filter User',
+    });
+
+    const friend = await User.create({
+      email: `discover-friend-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'My Friend Creator',
+    });
+
+    const stranger = await User.create({
+      email: `discover-stranger-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Stranger Creator',
+    });
+
+    await Friendship.create({
+      userId: user.id,
+      friendId: friend.id,
+      status: 'accepted',
+    });
+
+    const friendCompName = `Friend Comp ${Date.now()}`;
+    const strangerCompName = `Stranger Comp ${Date.now()}`;
+
+    await Competition.create({
+      name: friendCompName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: friend.id,
+      status: 'active',
+    });
+
+    await Competition.create({
+      name: strangerCompName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: stranger.id,
+      status: 'active',
+    });
+
+    const response = await client
+      .get('/competitions/discover')
+      .qs({ source: 'friends' })
+      .loginAs(user)
+      .withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const foundFriend = props.competitions.find((c: any) => c.competition.name === friendCompName);
+    const foundStranger = props.competitions.find(
+      (c: any) => c.competition.name === strangerCompName,
+    );
+
+    assert.isDefined(foundFriend);
+    assert.isUndefined(foundStranger);
+  });
+
+  test('includes user membership status', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-membership-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Membership Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-membership-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Membership Creator',
+    });
+
+    const compName = `Joined Competition ${Date.now()}`;
+
+    const competition = await Competition.create({
+      name: compName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    await CompetitionMember.create({
+      competitionId: competition.id,
+      userId: user.id,
+      status: 'accepted',
+      invitedBy: creator.id,
+    });
+
+    const response = await client.get('/competitions/discover').loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === compName);
+
+    assert.isDefined(found);
+    assert.equal(found.userMembershipStatus, 'accepted');
+  });
+
+  test('includes member count', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `discover-count-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Count Test User',
+    });
+
+    const creator = await User.create({
+      email: `discover-count-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Count Creator',
+    });
+
+    const compName = `Count Competition ${Date.now()}`;
+
+    const competition = await Competition.create({
+      name: compName,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    await CompetitionMember.create({
+      competitionId: competition.id,
+      userId: creator.id,
+      status: 'accepted',
+      invitedBy: null,
+    });
+
+    const response = await client.get('/competitions/discover').loginAs(user).withInertia();
+
+    response.assertStatus(200);
+
+    const props = response.inertiaProps as any;
+    const found = props.competitions.find((c: any) => c.competition.name === compName);
+
+    assert.isDefined(found);
+    assert.equal(found.memberCount, 1);
+  });
+
+  test('requires authentication', async ({ client }) => {
+    const response = await client.get('/competitions/discover').redirects(0);
+
+    response.assertStatus(302);
+  });
+});
+
+test.group('CompetitionDiscoveryController - join', () => {
+  test('user can join a public competition', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `join-user-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Join User',
+    });
+
+    const creator = await User.create({
+      email: `join-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Join Creator',
+    });
+
+    const competition = await Competition.create({
+      name: `Join Test ${Date.now()}`,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    const response = await client
+      .post(`/competitions/${competition.id}/join`)
+      .withCsrfToken()
+      .loginAs(user)
+      .redirects(0);
+
+    response.assertStatus(302);
+    response.assertHeader('location', `/competitions/${competition.id}`);
+
+    const membership = await CompetitionMember.query()
+      .where('competition_id', competition.id)
+      .where('user_id', user.id)
+      .firstOrFail();
+
+    assert.equal(membership.status, 'accepted');
+    assert.isNull(membership.invitedBy);
+  });
+
+  test('cannot join a private competition', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `join-private-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Private Join User',
+    });
+
+    const creator = await User.create({
+      email: `join-private-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Private Join Creator',
+    });
+
+    const competition = await Competition.create({
+      name: `Private Join Test ${Date.now()}`,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'private',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    const response = await client
+      .post(`/competitions/${competition.id}/join`)
+      .withCsrfToken()
+      .loginAs(user)
+      .redirects(0);
+
+    response.assertStatus(302);
+
+    const membership = await CompetitionMember.query()
+      .where('competition_id', competition.id)
+      .where('user_id', user.id)
+      .first();
+
+    assert.isNull(membership);
+  });
+
+  test('cannot join a competition twice', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `join-twice-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Twice Join User',
+    });
+
+    const creator = await User.create({
+      email: `join-twice-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Twice Join Creator',
+    });
+
+    const competition = await Competition.create({
+      name: `Twice Join Test ${Date.now()}`,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+    });
+
+    await CompetitionMember.create({
+      competitionId: competition.id,
+      userId: user.id,
+      status: 'accepted',
+      invitedBy: null,
+    });
+
+    const response = await client
+      .post(`/competitions/${competition.id}/join`)
+      .withCsrfToken()
+      .loginAs(user)
+      .redirects(0);
+
+    response.assertStatus(302);
+
+    const memberships = await CompetitionMember.query()
+      .where('competition_id', competition.id)
+      .where('user_id', user.id);
+
+    assert.equal(memberships.length, 1);
+  });
+
+  test('cannot join a draft competition', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `join-draft-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Draft Join User',
+    });
+
+    const creator = await User.create({
+      email: `join-draft-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Draft Join Creator',
+    });
+
+    const competition = await Competition.create({
+      name: `Draft Join Test ${Date.now()}`,
+      startDate: DateTime.now().plus({ days: 10 }),
+      endDate: DateTime.now().plus({ days: 40 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'draft',
+    });
+
+    const response = await client
+      .post(`/competitions/${competition.id}/join`)
+      .withCsrfToken()
+      .loginAs(user)
+      .redirects(0);
+
+    response.assertStatus(302);
+
+    const membership = await CompetitionMember.query()
+      .where('competition_id', competition.id)
+      .where('user_id', user.id)
+      .first();
+
+    assert.isNull(membership);
+  });
+
+  test('cannot join a deleted competition', async ({ client, assert }) => {
+    const user = await User.create({
+      email: `join-deleted-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Deleted Join User',
+    });
+
+    const creator = await User.create({
+      email: `join-deleted-creator-${Date.now()}@example.com`,
+      password: 'password123',
+      fullName: 'Deleted Join Creator',
+    });
+
+    const competition = await Competition.create({
+      name: `Deleted Join Test ${Date.now()}`,
+      startDate: DateTime.now().minus({ days: 1 }),
+      endDate: DateTime.now().plus({ days: 30 }),
+      goalType: 'total_steps',
+      visibility: 'public',
+      createdBy: creator.id,
+      status: 'active',
+      deletedAt: DateTime.now(),
+    });
+
+    const response = await client
+      .post(`/competitions/${competition.id}/join`)
+      .withCsrfToken()
+      .loginAs(user)
+      .redirects(0);
+
+    response.assertStatus(404);
+
+    const membership = await CompetitionMember.query()
+      .where('competition_id', competition.id)
+      .where('user_id', user.id)
+      .first();
+
+    assert.isNull(membership);
+  });
+
+  test('join requires authentication', async ({ client }) => {
+    const response = await client.post('/competitions/1/join').redirects(0);
+
+    response.assertStatus(302);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `/competitions/discover` page where users can browse and join public competitions
- Includes search, status (active/ended), and source (all/friends) filters with debounced search input
- Draft competitions are excluded from discovery and cannot be joined
- Adds "Discover" button to the competitions index page header and empty state

## Test plan
- [x] 14 new functional tests covering discovery filtering and join behavior
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 69/69 passing

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)